### PR TITLE
Fix compilation of examples with `-prod` with latest V

### DIFF
--- a/area_graph.v
+++ b/area_graph.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 import math
 import math.stats

--- a/builtin_dialogs.v
+++ b/builtin_dialogs.v
@@ -3,11 +3,9 @@ module mui
 import time
 import gx
 
-const (
-    dialogs_null_answer = "@mui_answer_null"
-    dialogs_wait_time   = 200
-    hex_chars           = ["0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F"]
-)
+const dialogs_null_answer = "@mui_answer_null"
+const dialogs_wait_time   = 200
+const hex_chars           = ["0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F"]
 
 fn dialogs_messagebox_cancel(event_details EventDetails, mut app &Window, mut app_data voidptr){
     app.clear_dialog()

--- a/button.v
+++ b/button.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 @[autofree_bug; manualfree]

--- a/checkbox.v
+++ b/checkbox.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 @[autofree_bug; manualfree]

--- a/examples/cells.v
+++ b/examples/cells.v
@@ -1,11 +1,10 @@
 import malisipi.mui as m
 
-const (
-    cols=["A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z"]
-    rows=100
-    cell_size=[80,25]
-    view_area=[(cols.len+1)*cell_size[0],(rows+1)*cell_size[1]]
-)
+const cols=["A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z"]
+const rows=100
+const cell_size=[80,25]
+const view_area=[(cols.len+1)*cell_size[0],(rows+1)*cell_size[1]]
+
 fn is_this_number(value string) bool { return value.int() != 0 || (value.int()==0 && value.replace("0","").len==0) }
 
 fn calculate_cell(mut app &m.Window, value string) int {

--- a/examples/demo.v
+++ b/examples/demo.v
@@ -1,8 +1,6 @@
 import malisipi.mui as m
 
-const (
-	countries=["United States","Canada","United Kingdom", "Australia"]
-)
+const countries=["United States","Canada","United Kingdom", "Australia"]
 
 @[unsafe]
 fn add_user(event_details m.EventDetails, mut app &m.Window, mut app_data voidptr){

--- a/examples/demo_no_console.v
+++ b/examples/demo_no_console.v
@@ -1,10 +1,7 @@
 import malisipi.mui as m
 import malisipi.mui.window as w
 
-const (
-	countries=["United States","Canada","United Kingdom", "Australia"]
-)
-
+const countries=["United States","Canada","United Kingdom", "Australia"]
 
 @[unsafe]
 fn add_user(event_details m.EventDetails, mut app &m.Window, mut app_data voidptr){

--- a/examples/demo_with_custom_font.v
+++ b/examples/demo_with_custom_font.v
@@ -1,8 +1,6 @@
 import malisipi.mui as m
 
-const (
-	countries=["United States","Canada","United Kingdom", "Australia"]
-)
+const countries=["United States","Canada","United Kingdom", "Australia"]
 
 @[unsafe]
 fn add_user(event_details m.EventDetails, mut app &m.Window, mut app_data voidptr){

--- a/examples/demo_with_list.v
+++ b/examples/demo_with_list.v
@@ -1,8 +1,6 @@
 import malisipi.mui as m
 
-const (
-	countries=["United States","Canada","United Kingdom", "Australia"]
-)
+const countries=["United States","Canada","United Kingdom", "Australia"]
 
 fn add_user(event_details m.EventDetails, mut app &m.Window, mut app_data voidptr){
 	unsafe{

--- a/examples/demo_with_menubar.v
+++ b/examples/demo_with_menubar.v
@@ -1,8 +1,6 @@
 import malisipi.mui as m
 
-const (
-	countries=["United States","Canada","United Kingdom", "Australia"]
-)
+const countries=["United States","Canada","United Kingdom", "Australia"]
 
 @[unsafe]
 fn add_user(event_details m.EventDetails, mut app &m.Window, mut app_data voidptr){

--- a/examples/notepad.v
+++ b/examples/notepad.v
@@ -1,10 +1,8 @@
 import malisipi.mui as m
 import os
 
-const (
-    open_file_emoji="⤵"
-    save_file_emoji="💾"
-)
+const open_file_emoji="⤵"
+const save_file_emoji="💾"
 
 struct AppData {
 mut:

--- a/examples/old_notepad.v
+++ b/examples/old_notepad.v
@@ -1,10 +1,8 @@
 import malisipi.mui as m
 import os
 
-const (
-    open_file_emoji="⤵"
-    save_file_emoji="💾"
-)
+const open_file_emoji="⤵"
+const save_file_emoji="💾"
 
 struct AppData {
 mut:

--- a/examples/player.v
+++ b/examples/player.v
@@ -3,11 +3,9 @@ import miniaudio as ma // v install https://github.com/malisipi/miniaudio
 import math
 import time
 
-const (
-    open_file_emoji="⤵"
-    play_emoji="▶️"
-    pause_emoji="⏸️"
-)
+const open_file_emoji="⤵"
+const play_emoji="▶️"
+const pause_emoji="⏸️"
 
 struct AppData{
 mut:

--- a/frame.v
+++ b/frame.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 @[autofree_bug; manualfree]

--- a/group.v
+++ b/group.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 @[autofree_bug; manualfree]

--- a/hyperlink.v
+++ b/hyperlink.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 @[autofree_bug; manualfree]

--- a/input.v
+++ b/input.v
@@ -1,8 +1,6 @@
 module mui
 
-const (
-	is_japanese = is_system_language_japanese_checker()
-)
+const is_japanese = is_system_language_japanese_checker()
 
 fn is_system_language_japanese_checker () bool {
 	return $if support_japanese_input? {

--- a/japanese_input.v
+++ b/japanese_input.v
@@ -1,7 +1,6 @@
 module mui
 
-const (
-	hiragana_list={
+const hiragana_list={
 		"んあ":"な", //fix na/ni/nu/ne/no letters
 		"んい":"に",
 		"んう":"ぬ",
@@ -116,9 +115,8 @@ const (
 		"pya":"ぴゃ",
 		"pyu":"ぴゅ",
 		"pyo":"ぴょ"
-	}
-	hiragana_keys=unsafe { hiragana_list.keys().clone().reverse() }
-)
+}    
+const hiragana_keys=unsafe { hiragana_list.keys().clone().reverse() }
 
 fn replace_romanji_with_hiragana (romanji string) string {
 	mut hiragana := romanji.clone()

--- a/label.v
+++ b/label.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 @[autofree_bug; manualfree]

--- a/line_graph.v
+++ b/line_graph.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 import math
 import math.stats

--- a/list.v
+++ b/list.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 pub fn add_list(mut app &Window, table [][]string, id string, x IntOrString, y IntOrString, w IntOrString, h IntOrString, hi bool, bg gx.Color, bfg gx.Color, fg gx.Color, frame string, zindex int, fnchg OnEvent, selected int, tSize int, row_h int){

--- a/mwm/mwm.v
+++ b/mwm/mwm.v
@@ -1,9 +1,7 @@
 module mwm
 import malisipi.mui
 
-pub const (
-	destroy = "@MUI_DESTROY" 
-)
+pub const destroy = "@MUI_DESTROY" 
 
 pub struct MuiWindowManager{
 pub mut:

--- a/open_street_map_linux.c.v
+++ b/open_street_map_linux.c.v
@@ -6,9 +6,7 @@ import os
 import gg
 import gx
 
-const (
-    map_source="© OpenStreetMap"
-)
+const map_source="© OpenStreetMap"
 
 // https://wiki.openstreetmap.org/w/index.php?title=Slippy_map_tilenames&oldid=2309797
 // Python - Lon./lat. to tile numbers

--- a/open_street_map_macos.c.v
+++ b/open_street_map_macos.c.v
@@ -6,9 +6,7 @@ import os
 import gg
 import gx
 
-const (
-    map_source="© OpenStreetMap"
-)
+const map_source="© OpenStreetMap"
 
 // https://wiki.openstreetmap.org/w/index.php?title=Slippy_map_tilenames&oldid=2309797
 // Python - Lon./lat. to tile numbers

--- a/open_street_map_windows.c.v
+++ b/open_street_map_windows.c.v
@@ -6,9 +6,7 @@ import os
 import gg
 import gx
 
-const (
-    map_source="© OpenStreetMap"
-)
+const map_source="© OpenStreetMap"
 
 // https://wiki.openstreetmap.org/w/index.php?title=Slippy_map_tilenames&oldid=2309797
 // Python - Lon./lat. to tile numbers

--- a/passwordbox.v
+++ b/passwordbox.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 pub fn add_password(mut app &Window, text string, hider_char string, id string, placeholder string, x IntOrString, y IntOrString, w IntOrString, h IntOrString, hi bool, bg gx.Color,  bfg gx.Color, fg gx.Color,  fnchg OnEvent, dialog bool, frame string, zindex int, tSize int){

--- a/progress.v
+++ b/progress.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 pub fn add_progress(mut app &Window, percent int, id string, x IntOrString, y IntOrString, w IntOrString, h IntOrString, hi bool, bg gx.Color,  bfg gx.Color, fg gx.Color, dialog bool, frame string, zindex int, tSize int){

--- a/rect.v
+++ b/rect.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 pub fn add_rect(mut app &Window, id string, x IntOrString, y IntOrString, w IntOrString, h IntOrString, hi bool, bg gx.Color, dialog bool, frame string, zindex int){

--- a/scrollbar.v
+++ b/scrollbar.v
@@ -1,11 +1,8 @@
 module mui
 
-import gg
 import gx
 
-pub const (
-    scrollbar_size=15
-)
+pub const scrollbar_size=15
 
 @[unsafe]
 fn update_scroll_hor(event_details EventDetails, mut app &Window, mut app_data voidptr){

--- a/selectbox.v
+++ b/selectbox.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 @[autofree_bug; manualfree]

--- a/slider.v
+++ b/slider.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 pub fn add_slider(mut app &Window, val int, min int, max int, step int, id string, x IntOrString, y IntOrString, w IntOrString, h IntOrString, vert bool, hi bool, bg gx.Color,  bfg gx.Color, fg gx.Color, fnclk OnEvent, fnchg OnEvent, fnucl OnEvent, value_map ValueMap, dialog bool, frame string, zindex int, tSize int, show_value_as_label int){

--- a/spinner.v
+++ b/spinner.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 pub fn add_spinner(mut app &Window, text string, id string, placeholder string, phsa bool, x IntOrString, y IntOrString, w IntOrString, h IntOrString, hi bool, bg gx.Color,  bfg gx.Color, fg gx.Color,  fnchg OnEvent, dialog bool, frame string, zindex int, tSize int){

--- a/switch.v
+++ b/switch.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 pub fn add_switch(mut app &Window, text string, id string, x IntOrString, y IntOrString, w IntOrString, h IntOrString, checked bool, hi bool, bg gx.Color, bfg gx.Color, fg gx.Color, fnchg OnEvent, frame string, zindex int, tSize int, show_value_as_label int){

--- a/table.v
+++ b/table.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 pub fn add_table(mut app &Window, table [][]string, id string, x IntOrString, y IntOrString, w IntOrString, h IntOrString, hi bool, bg gx.Color, bfg gx.Color, fg gx.Color, frame string, zindex int, tSize int, row_h int){

--- a/textarea.v
+++ b/textarea.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 pub fn add_textarea(mut app &Window, text string, id string, placeholder string, phsa bool, x IntOrString, y IntOrString, w IntOrString, h IntOrString, hi bool, bg gx.Color,  bfg gx.Color, fg gx.Color,  fnchg OnEvent, codefield bool, tSize int, frame string, zindex int){

--- a/textbox.v
+++ b/textbox.v
@@ -1,6 +1,5 @@
 module mui
 
-import gg
 import gx
 
 pub fn add_textbox(mut app &Window, text string, id string, placeholder string, phsa bool, x IntOrString, y IntOrString, w IntOrString, h IntOrString, hi bool, bg gx.Color,  bfg gx.Color, fg gx.Color,  fnchg OnEvent, dialog bool, frame string, zindex int, tSize int){

--- a/themes.v
+++ b/themes.v
@@ -5,31 +5,27 @@ import strconv
 import gx
 import math
 
-pub const (
-	theme_dark=[40,40,40]
-	theme_light=[225,225,225]
-	user_light_theme=is_light_theme()
-	user_accent_color=theme_accent_color()
-)
+pub const theme_dark=[40,40,40]
+pub const theme_light=[225,225,225]
+pub const user_light_theme=is_light_theme()
+pub const user_accent_color=theme_accent_color()
 
-const (
-	theme_windows_light=PredefinedTheme{
+const theme_windows_light=PredefinedTheme{
 		color_scheme: [gx.Color{r:240,g:240,b:240}, gx.Color{r:253,g:253,b:253}, gx.Color{r:0,g:120,b:212}, gx.Color{r:0,g:0,b:0}]
 		round_corner: 5
-	}
-	theme_windows_dark=PredefinedTheme{
+}
+const theme_windows_dark=PredefinedTheme{
 		color_scheme: [gx.Color{r:32,g:33,b:36}, gx.Color{r:53,g:54,b:58}, gx.Color{r:69,g:178,b:235}, gx.Color{r:243,g:243,b:243}],
 		round_corner: 5
-	}
-	theme_linux_light=PredefinedTheme{
+}
+const theme_linux_light=PredefinedTheme{
 		color_scheme: [gx.Color{r:250,g:250,b:250}, gx.Color{r:212,g:212,b:212}, gx.Color{r:236,g:100,b:53}, gx.Color{r:42,g:42,b:42}]
 		round_corner: 5
-	}
-	theme_linux_dark=PredefinedTheme{
+}
+const theme_linux_dark=PredefinedTheme{
 		color_scheme: [gx.Color{r:48,g:48,b:48}, gx.Color{r:68,g:68,b:68}, gx.Color{r:236,g:100,b:53}, gx.Color{r:255,g:255,b:255}],
 		round_corner: 5
-	}
-)
+}
 
 fn hex_to_rgb(color string) []int {
 	clr:=color.replace("#","")

--- a/transitions.v
+++ b/transitions.v
@@ -2,10 +2,8 @@ module mui
 
 import time
 
-const (
-    transition_fps=60
-    transition_time=f64(1)/transition_fps
-)
+const transition_fps=60
+const transition_time=f64(1)/transition_fps
 
 pub fn move_object(mut app &Window, object_id string, new_pos []IntOrString, move_time f64){
     unsafe {

--- a/types.v
+++ b/types.v
@@ -3,10 +3,8 @@ module mui
 import gg
 import gx
 
-pub const (
-	null_object={"id":WindowData{str:""}}
-	window_titlebar_height = 30
-)
+pub const null_object={"id":WindowData{str:""}}
+pub const window_titlebar_height = 30
 
 pub type IntOrString=int|string
 pub type U32OrString=u32|string

--- a/types_android.c.v
+++ b/types_android.c.v
@@ -2,7 +2,6 @@ module mui
 
 import os.font
 
-const (
-    text_cursor="|"
-    os_font=font.default()
-)
+const text_cursor="|"
+const os_font=font.default()
+

--- a/types_default.c.v
+++ b/types_default.c.v
@@ -5,7 +5,5 @@ pub fn C.emscripten_run_script_string(&char) &char
 pub fn C.emscripten_sleep(int)
 //pub fn C.emscripten_run_async_script(&char)
 
-const (
-    text_cursor="|"
-    os_font="noto.ttf"
-)
+const text_cursor="|"
+const os_font="noto.ttf"

--- a/types_linux.c.v
+++ b/types_linux.c.v
@@ -2,7 +2,5 @@ module mui
 
 import os.font
 
-const (
-    text_cursor="|"
-    os_font=font.default()
-)
+const text_cursor="|"
+const os_font=font.default()

--- a/types_macos.c.v
+++ b/types_macos.c.v
@@ -2,7 +2,5 @@ module mui
 
 import os.font
 
-const (
-    text_cursor="|"
-    os_font=font.default()
-)
+const text_cursor="|"
+const os_font=font.default()

--- a/types_windows.c.v
+++ b/types_windows.c.v
@@ -3,10 +3,8 @@ module mui
 import os
 import os.font
 
-const (
-    text_cursor="|"
-    os_font=get_os_font()
-)
+const text_cursor="|"
+const os_font=get_os_font()
 
 fn get_os_font()string{
     if os.exists("C:/Windows/Fonts/segoeui.ttf"){


### PR DESCRIPTION
In latest V, there is a warning for using `const ( ... )` blocks.
There were also some unused `gg` imports which also produced warnings.

With the changes in this PR, this ran cleanly for me:
```
v -prod -cflags "-Wno-int-conversion -Wno-incompatible-pointer-types -Wno-incompatible-function-pointer-types" -no-parallel run ~/.vmodules/malisipi/mui/examples/labels.v
```

I will try to fix the need for the cflags with latest clang on macos in another PR.